### PR TITLE
Change plugin installed during tests as repository-s3 is now included in ES by default

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,7 +16,7 @@
         - test-molecule
 
       es_plugins:
-        - name: repository-s3
+        - name: discovery-ec2
 
       es_keystore_entries:
         - key: s3.client.default.access_key

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -79,7 +79,7 @@ def test_indices_exist(host, user, password, indice):
 @pytest.mark.parametrize(
     "plugin",
     [
-        ("repository-s3"),
+        ("discovery-ec2"),
     ],
 )
 def test_plugins_exist(host, plugin):

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -19,7 +19,6 @@
 
 - name: Ensure plugins are installed
   community.general.elasticsearch_plugin:
-    force: true
     name: "{{ item.name }}"
     version: "{{ item.version | d(omit) }}"
   loop: "{{ es_plugins }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -19,6 +19,8 @@
 
 - name: Ensure plugins are installed
   community.general.elasticsearch_plugin:
+    force: true
     name: "{{ item.name }}"
     version: "{{ item.version | d(omit) }}"
   loop: "{{ es_plugins }}"
+  notify: Restart ElasticSearch


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3.html